### PR TITLE
make work for xbox version of the game

### DIFF
--- a/Objects/TrackerHolder.cs
+++ b/Objects/TrackerHolder.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using MelonLoader.TinyJSON;
+using MelonLoader.Utils;
 using UnityEngine;
 using Settings = EventTracker.EventTracker.Settings;
 
@@ -47,6 +48,16 @@ namespace EventTracker.Objects
         {
             if (level == null)
                 level = Singleton<Game>.Instance.GetCurrentLevel();
+
+            // currentPlatform is set to Platform.BITCODE on Xbox version
+            bool isXbox = GameData.currentPlatform != Platform.STEAM;
+            if (isXbox)
+            {
+                string xboxPath = Path.Combine(MelonEnvironment.UserDataDirectory, "EventTracker", level.levelID);
+                Directory.CreateDirectory(xboxPath);
+                return xboxPath + "/";
+            }
+
             string path = GhostRecorder.GetCompressedSavePathForLevel(level);
             path = Path.GetDirectoryName(path) + "/";
             return path;
@@ -367,7 +378,7 @@ namespace EventTracker.Objects
             if (!Settings.AdvancedMode.Value && !pb && pools != null && !early)
             {
                 // we might not have our actual PB but it might be better than what we have on record
-                if (time < pools["Goal"][0].Item2)
+                if (pools.TryGetValue("Goal", out var goal) && time < goal[0].Item2)
                     pb = true;
             }
 


### PR DESCRIPTION
The directory the game creates ghosts in is not accessible on the Xbox version of the game (weird windows permissions locking it down) so the place tracker files are saved like `C:\XboxGames\Neon White\Content\UserData\EventTracker\TUT_BOMB2\tracker.txt` on a typical Xbox installation.

Also fixes a bug where it throws if a tracker file does not already exist for the level.